### PR TITLE
Fix receipt slug migration duplicate index on Postgres

### DIFF
--- a/receipts/migrations/0004_receipt_slug.py
+++ b/receipts/migrations/0004_receipt_slug.py
@@ -46,7 +46,7 @@ class Migration(migrations.Migration):
             model_name="receipt",
             name="slug",
             field=models.CharField(
-                blank=True, db_index=True, max_length=10, default=''
+                blank=True, max_length=10, default=''
             ),
         ),
         # Generate slugs for existing receipts
@@ -59,7 +59,7 @@ class Migration(migrations.Migration):
             model_name="receipt",
             name="slug",
             field=models.CharField(
-                blank=True, db_index=True, max_length=10, unique=True
+                blank=True, max_length=10, unique=True
             ),
         ),
     ]

--- a/receipts/models.py
+++ b/receipts/models.py
@@ -15,7 +15,7 @@ class Receipt(models.Model):
     ]
     
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    slug = models.CharField(max_length=10, unique=True, db_index=True, blank=True)
+    slug = models.CharField(max_length=10, unique=True, blank=True)
     uploader_name = models.CharField(max_length=50)
     restaurant_name = models.CharField(max_length=100)
     date = models.DateTimeField()


### PR DESCRIPTION
## Summary
- remove the redundant `db_index` flag from the receipt slug model/migration so Django no longer tries to create a duplicate LIKE index on Postgres when the unique constraint is added

## Testing
- `python - <<'PY' ... execute_from_command_line(['manage.py','migrate'])`
- `python - <<'PY' ... execute_from_command_line(['manage.py','test','receipts','-v','2'])` *(fails: existing suite requires built static asset manifest and other fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68ca517efb70832abe07dc8cac6efef4