### PR TITLE
Fix double-escaped text in Venmo links/displays and iOS tap targets

### DIFF
--- a/receipts/validators.py
+++ b/receipts/validators.py
@@ -5,6 +5,7 @@ Provides comprehensive validation for file uploads and user inputs
 
 from django.core.exceptions import ValidationError
 from PIL import Image
+import html
 import logging
 from decimal import Decimal, InvalidOperation
 import hashlib
@@ -14,6 +15,18 @@ import bleach
 import magic
 
 logger = logging.getLogger(__name__)
+
+
+def strip_html_tags(value):
+    """Strip HTML tags from text without HTML-escaping the result.
+
+    bleach.clean() escapes special characters (& < >) as HTML entities, but we
+    store raw text in the database — Django templates escape on output. Storing
+    entities would double-escape on render (literal "&amp;") and leak entities
+    into URL parameters (e.g. Venmo notes). html.unescape() exactly reverses
+    the single escaping pass bleach applies.
+    """
+    return html.unescape(bleach.clean(value, tags=[], strip=True))
 
 
 class FileUploadValidator:
@@ -144,8 +157,8 @@ class InputValidator:
         # Strip whitespace
         name = name.strip()
         
-        # Remove any HTML tags and dangerous characters using bleach
-        name = bleach.clean(name, tags=[], strip=True)
+        # Remove any HTML tags and dangerous characters (without escaping)
+        name = strip_html_tags(name)
         
         # Check length after cleaning
         if len(name) < min_length:
@@ -218,7 +231,7 @@ class InputValidator:
         
         # Always clean restaurant name, even if validation fails
         original_name = data.get('restaurant_name', '')
-        cleaned_name = bleach.clean(original_name, tags=[], strip=True).strip()
+        cleaned_name = strip_html_tags(original_name).strip()
         
         try:
             data['restaurant_name'] = InputValidator.validate_name(
@@ -259,7 +272,7 @@ class InputValidator:
             for i, item in enumerate(data.get('items', [])):
                 # Always clean item name, even if validation fails
                 original_item_name = item.get('name', '')
-                cleaned_item_name = bleach.clean(original_item_name, tags=[], strip=True).strip()
+                cleaned_item_name = strip_html_tags(original_item_name).strip()
                 
                 try:
                     item['name'] = InputValidator.validate_name(

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -378,6 +378,23 @@
    Utility Classes
    ========================================================================== */
 
+/* Minimum 44x44px effective touch target (iOS HIG) without growing the visual.
+   The transparent ::after box extends the element's hit area to at least
+   44x44px, centered on the element. Buttons/links only — inputs cannot render
+   pseudo-elements, so give them a real height of 44px (h-11) instead. */
+.tap-target {
+  position: relative;
+}
+.tap-target::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: max(100%, 44px);
+  height: max(100%, 44px);
+  transform: translate(-50%, -50%);
+}
+
 /* Focus visible for accessibility */
 .focus-visible:focus {
   outline: 2px solid var(--color-primary-600);

--- a/static/js/view-page.js
+++ b/static/js/view-page.js
@@ -20,7 +20,7 @@ const MAX_POLLING_ERRORS = 3;
 
 // CSS class constants for claim inputs
 const CLAIM_INPUT_CLASSES = {
-    base: 'claim-quantity w-12 h-8 px-2 py-1 border rounded-lg text-center tabular-nums',
+    base: 'claim-quantity w-12 h-11 px-2 py-1 border rounded-lg text-center tabular-nums',
     enabled: 'border-gray-300 focus:ring-2 focus:ring-blue-500',
     disabled: 'border-gray-200 bg-gray-50 text-gray-600'
 };
@@ -862,7 +862,9 @@ function updateVenmoLink(amount) {
     const restaurantName = container.dataset.restaurantName;
     if (!venmoUsername) return;
 
-    const note = `You Owe - ${encodeURIComponent(restaurantName)} ${window.location.href}`;
+    // Encode the whole note exactly once — spaces become %20, & and + in
+    // names are percent-encoded, and no raw characters leak into the URL.
+    const note = encodeURIComponent(`You Owe - ${restaurantName} ${window.location.href}`);
     link.href = `https://venmo.com/${venmoUsername}?txn=pay&amount=${amount.toFixed(2)}&note=${note}`;
 }
 
@@ -1107,7 +1109,7 @@ function subdivideItemOnClaimPage(lineItemId) {
 
     options.forEach((val, idx) => {
         const label = document.createElement('label');
-        label.className = 'flex items-center space-x-3 p-2 rounded-lg hover:bg-gray-50 cursor-pointer';
+        label.className = 'flex items-center space-x-3 p-2.5 rounded-lg hover:bg-gray-50 cursor-pointer';
 
         const radio = document.createElement('input');
         radio.type = 'radio';
@@ -1145,12 +1147,12 @@ function subdivideItemOnClaimPage(lineItemId) {
     btnsDiv.className = 'flex justify-end space-x-2';
 
     const cancelBtn = document.createElement('button');
-    cancelBtn.className = 'bg-gray-200 text-gray-800 px-4 py-2 rounded-lg hover:bg-gray-300 font-medium';
+    cancelBtn.className = 'bg-gray-200 text-gray-800 px-4 py-2.5 rounded-lg hover:bg-gray-300 font-medium';
     cancelBtn.textContent = 'Cancel';
     cancelBtn.addEventListener('click', () => overlay.remove());
 
     const applyBtn = document.createElement('button');
-    applyBtn.className = 'bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 font-medium';
+    applyBtn.className = 'bg-blue-600 text-white px-4 py-2.5 rounded-lg hover:bg-blue-700 font-medium';
     applyBtn.textContent = 'Apply';
     applyBtn.addEventListener('click', async () => {
         // Check radio selection

--- a/templates/receipts/partials/claim_controls.html
+++ b/templates/receipts/partials/claim_controls.html
@@ -11,18 +11,18 @@ Context variables:
 {% with current_value=current_value|default:0 max_value=max_value|default:0 disabled=disabled|default:False size=size|default:'normal' %}
 <div class="flex items-center space-x-1">
     <button type="button" 
-            class="claim-minus {% if size == 'compact' %}h-6 w-6 text-xs{% else %}h-8 w-8 text-sm{% endif %} rounded-lg flex items-center justify-center text-white font-medium {% if disabled or current_value == 0 %}bg-gray-300 cursor-not-allowed{% else %}bg-orange-600 hover:bg-orange-700{% endif %}" 
+            class="claim-minus tap-target {% if size == 'compact' %}h-8 w-8 text-xs{% else %}h-10 w-10 text-base{% endif %} rounded-lg flex items-center justify-center text-white font-medium {% if disabled or current_value == 0 %}bg-gray-300 cursor-not-allowed{% else %}bg-orange-600 hover:bg-orange-700{% endif %}"
             data-item-id="{{ item_id }}"
             {% if disabled or current_value == 0 %}disabled{% endif %}>−</button>
     <input type="number" 
-           class="claim-quantity {% if size == 'compact' %}w-10 h-6 px-1 py-0 text-xs{% else %}w-12 h-8 px-2 py-1{% endif %} border rounded-lg text-center tabular-nums {% if disabled %}border-gray-200 bg-gray-50 text-gray-600{% else %}border-gray-300 focus:ring-2 focus:ring-blue-500{% endif %}"
+           class="claim-quantity {% if size == 'compact' %}w-10 h-11 px-1 py-0 text-base{% else %}w-12 h-11 px-2 py-1{% endif %} border rounded-lg text-center tabular-nums {% if disabled %}border-gray-200 bg-gray-50 text-gray-600{% else %}border-gray-300 focus:ring-2 focus:ring-blue-500{% endif %}"
            min="0"
            max="{{ max_value }}"
            value="{{ current_value }}"
            data-item-id="{{ item_id }}"
            {% if disabled %}readonly disabled{% endif %}>
     <button type="button" 
-            class="claim-plus {% if size == 'compact' %}h-6 w-6 text-xs{% else %}h-8 w-8 text-sm{% endif %} rounded-lg flex items-center justify-center text-white font-medium {% if disabled or current_value >= max_value %}bg-gray-300 cursor-not-allowed{% else %}bg-green-600 hover:bg-green-700{% endif %}" 
+            class="claim-plus tap-target {% if size == 'compact' %}h-8 w-8 text-xs{% else %}h-10 w-10 text-base{% endif %} rounded-lg flex items-center justify-center text-white font-medium {% if disabled or current_value >= max_value %}bg-gray-300 cursor-not-allowed{% else %}bg-green-600 hover:bg-green-700{% endif %}"
             data-item-id="{{ item_id }}"
             {% if disabled or current_value >= max_value %}disabled{% endif %}>+</button>
 </div>

--- a/templates/receipts/partials/copy_link_widget.html
+++ b/templates/receipts/partials/copy_link_widget.html
@@ -4,13 +4,13 @@
                value="{{ share_url|escape }}" 
                readonly 
                id="{{ widget_id }}"
-               class="flex-1 px-3 py-2 {{ border_color|default:'border-gray-300' }} border rounded-l-lg {{ input_bg|default:'bg-gray-50' }}">
+               class="flex-1 px-3 py-2.5 {{ border_color|default:'border-gray-300' }} border rounded-l-lg {{ input_bg|default:'bg-gray-50' }}">
 
         <!-- QR Code Button -->
         {% if not show_qr_code_inline %}
         <button data-action="show-qr-code"
                 data-widget-id="{{ widget_id }}"
-                class="px-3 py-2 {{ border_color|default:'border-gray-300' }} border border-l-0 {{ button_bg|default:'bg-white' }} {{ button_hover|default:'hover:bg-blue-50' }} transition-colors"
+                class="tap-target px-3 py-2.5 {{ border_color|default:'border-gray-300' }} border border-l-0 {{ button_bg|default:'bg-white' }} {{ button_hover|default:'hover:bg-blue-50' }} transition-colors"
                 title="Show QR Code">
             <svg class="h-6 w-6 {{ icon_color|default:'text-blue-600' }}" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 5h-1m-4-5h1v1h-1V4zm-3 4h1v1H8V8zm12 5l-2.939 2.939a1 1 0 01-1.414 0L13 15m5 5v1m-6-5h-1m4 5h-1v1h1v-1zm-3-4h-1v1h1v-1zm-4-3v1m-3-4l2.939-2.939a1 1 0 011.414 0L9 7M4 5v1m3-4h1v1H7V2zm3 12h1v1h-1v-1zM5 4l-2.939 2.939a1 1 0 000 1.414L5 11m-1 5v1m0-6H3m1-4h1v1H4V6zm14 7l2.939-2.939a1 1 0 000-1.414L15 9m5-5h-1"></path></svg>
         </button>
@@ -19,7 +19,7 @@
         <!-- Native share button (mobile only) -->
         <button data-action="native-share"
                 data-widget-id="{{ widget_id }}"
-                class="mobile-share-btn px-3 py-2 {{ border_color|default:'border-gray-300' }} border border-l-0 {{ button_bg|default:'bg-white' }} {{ button_hover|default:'hover:bg-blue-50' }} transition-colors hidden"
+                class="mobile-share-btn tap-target px-3 py-2.5 {{ border_color|default:'border-gray-300' }} border border-l-0 {{ button_bg|default:'bg-white' }} {{ button_hover|default:'hover:bg-blue-50' }} transition-colors hidden"
                 title="Share">
             <!-- Standard iOS/Android share icon -->
             <svg class="h-6 w-6 {{ icon_color|default:'text-blue-600' }}" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -28,7 +28,7 @@
         </button>
         <button data-action="copy-share-url"
                 data-widget-id="{{ widget_id }}"
-                class="px-3 py-2 {{ border_color|default:'border-gray-300' }} border border-l-0 rounded-r-lg {{ button_bg|default:'bg-white' }} {{ button_hover|default:'hover:bg-blue-50' }} transition-colors"
+                class="tap-target px-3 py-2.5 {{ border_color|default:'border-gray-300' }} border border-l-0 rounded-r-lg {{ button_bg|default:'bg-white' }} {{ button_hover|default:'hover:bg-blue-50' }} transition-colors"
                 title="Copy to clipboard">
             <div class="h-6 w-6 {{ icon_color|default:'text-blue-600' }} flex items-center justify-center text-lg font-bold">⧉</div>
         </button>
@@ -46,7 +46,7 @@
         <a data-action="share-whatsapp"
            data-widget-id="{{ widget_id }}"
            href="#"
-           class="flex-1 bg-green-500 text-white p-2 rounded-lg flex items-center justify-center hover:bg-green-600 transition-colors"
+           class="flex-1 bg-green-500 text-white p-2.5 rounded-lg flex items-center justify-center hover:bg-green-600 transition-colors"
            title="Share on WhatsApp">
             <!-- WhatsApp icon -->
             <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -56,7 +56,7 @@
         <a data-action="share-messenger"
            data-widget-id="{{ widget_id }}"
            href="#"
-           class="flex-1 bg-blue-500 text-white p-2 rounded-lg flex items-center justify-center hover:bg-blue-600 transition-colors"
+           class="flex-1 bg-blue-500 text-white p-2.5 rounded-lg flex items-center justify-center hover:bg-blue-600 transition-colors"
            title="Share on Messenger">
             <!-- Facebook Messenger icon -->
             <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -66,7 +66,7 @@
         <a data-action="share-sms"
            data-widget-id="{{ widget_id }}"
            href="#"
-           class="flex-1 bg-gray-600 text-white p-2 rounded-lg flex items-center justify-center hover:bg-gray-700 transition-colors"
+           class="flex-1 bg-gray-600 text-white p-2.5 rounded-lg flex items-center justify-center hover:bg-gray-700 transition-colors"
            title="Share via SMS">
             <!-- SMS/Messages icon -->
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -81,7 +81,7 @@
     <div class="bg-white rounded-lg p-6 max-w-md w-full mx-4 text-center">
         <h3 class="text-2xl font-semibold text-gray-900 mb-4">Scan QR Code</h3>
         <canvas id="qr-code-modal-canvas-{{ widget_id }}"></canvas>
-        <button data-action="close-qr-code-modal" data-widget-id="{{ widget_id }}" class="mt-4 w-full bg-gray-200 text-gray-800 px-6 py-2 rounded-lg hover:bg-gray-300 font-medium">
+        <button data-action="close-qr-code-modal" data-widget-id="{{ widget_id }}" class="mt-4 w-full bg-gray-200 text-gray-800 px-6 py-2.5 rounded-lg hover:bg-gray-300 font-medium">
             Close
         </button>
     </div>

--- a/templates/receipts/partials/item_row_display.html
+++ b/templates/receipts/partials/item_row_display.html
@@ -24,7 +24,7 @@ Context: item (LineItem), show_calculations, show_claims, claims, viewer_name, r
         <div class="ml-4 flex-shrink-0 flex items-center space-x-2">
             {% if not is_user_finalized %}
             <button type="button"
-                    class="h-8 w-8 rounded-lg flex items-center justify-center text-white font-medium bg-purple-600 hover:bg-purple-700 text-sm"
+                    class="tap-target h-10 w-10 rounded-lg flex items-center justify-center text-white font-medium bg-purple-600 hover:bg-purple-700 text-base"
                     data-action="subdivide-claim-item"
                     data-item-id="{{ item.id }}"
                     title="Split into parts">÷</button>

--- a/templates/receipts/partials/item_row_editable.html
+++ b/templates/receipts/partials/item_row_editable.html
@@ -28,7 +28,7 @@ Context: item (LineItem object, optional), container_class (optional)
                     <input type="text"
                            value="{% if item %}{{ item.quantity_numerator }}{% if item.quantity_denominator != 1 %}/{{ item.quantity_denominator }}{% endif %}{% else %}1{% endif %}"
                            placeholder="Qt"
-                           class="item-quantity w-1/2 flex-grow px-1 sm:px-2 py-2 border border-gray-300 rounded-l-lg text-sm focus:ring-2 focus:ring-blue-500 text-center tabular-nums"
+                           class="item-quantity w-1/2 flex-grow px-1 sm:px-2 py-2 border border-gray-300 rounded-l-lg text-base focus:ring-2 focus:ring-blue-500 text-center tabular-nums"
                            readonly>
                     <button data-action="subdivide-item" class="bg-gray-200 text-gray-700 px-2 py-2 border-t border-b border-r border-gray-300 rounded-r-lg hover:bg-gray-300 text-sm font-medium">÷</button>
                 </div>
@@ -38,7 +38,7 @@ Context: item (LineItem object, optional), container_class (optional)
                            value="{% if item %}{{ item.unit_price|floatformat:2 }}{% endif %}"
                            step="0.01"
                            placeholder="Price"
-                           class="item-price w-full px-2 sm:px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 text-right tabular-nums">
+                           class="item-price w-full px-2 sm:px-3 py-2 border border-gray-300 rounded-lg text-base focus:ring-2 focus:ring-blue-500 text-right tabular-nums">
                 </div>
                 <span class="text-gray-500 font-medium">=</span>
                 <div class="flex-1 sm:w-28">
@@ -46,7 +46,7 @@ Context: item (LineItem object, optional), container_class (optional)
                            value="{% if item %}{{ item.total_price|floatformat:2 }}{% endif %}"
                            step="0.01"
                            placeholder="Total"
-                           class="item-total w-full px-2 sm:px-3 py-2 border border-gray-300 rounded-lg text-sm font-semibold focus:ring-2 focus:ring-blue-500 text-right tabular-nums bg-gray-50"
+                           class="item-total w-full px-2 sm:px-3 py-2 border border-gray-300 rounded-lg text-base font-semibold focus:ring-2 focus:ring-blue-500 text-right tabular-nums bg-gray-50"
                            readonly>
                 </div>
             </div>

--- a/templates/receipts/view.html
+++ b/templates/receipts/view.html
@@ -21,14 +21,14 @@
                        required
                        minlength="2"
                        maxlength="50"
-                       class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+                       class="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
                        placeholder="Enter your name">
                 <input type="text"
                        name="viewer_venmo"
                        maxlength="31"
-                       class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+                       class="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
                        placeholder="Venmo username (optional)">
-                <button type="submit" class="w-full bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 font-medium">
+                <button type="submit" class="w-full bg-blue-600 text-white px-6 py-2.5 rounded-lg hover:bg-blue-700 font-medium">
                     Continue
                 </button>
             </div>
@@ -98,10 +98,10 @@
                             <div class="flex items-center gap-2">
                                 <span class="font-medium tabular-nums">${{ participant.amount|floatformat:2 }}</span>
                                 {% if is_uploader and participant.venmo_username and participant.name != receipt.uploader_name %}
-                                <a href="https://venmo.com/{{ participant.venmo_username }}?txn=charge&amount={{ participant.amount|floatformat:2 }}&note=You%20Owe%20-%20{{ receipt.restaurant_name|urlencode }}%20{{ share_url }}"
+                                <a href="https://venmo.com/{{ participant.venmo_username }}?txn=charge&amount={{ participant.amount|floatformat:2 }}&note=You%20Owe%20-%20{{ receipt.restaurant_name|urlencode:"" }}%20{{ share_url|urlencode:"" }}"
                                    target="_blank"
                                    rel="noopener noreferrer"
-                                   class="text-xs px-2 py-0.5 bg-[#008CFF] text-white rounded font-medium hover:bg-[#0070CC] transition-colors"
+                                   class="tap-target text-xs px-3 py-1.5 bg-[#008CFF] text-white rounded font-medium hover:bg-[#0070CC] transition-colors"
                                    title="Request ${{ participant.amount|floatformat:2 }} from {{ participant.name }}">Venmo</a>
                                 {% endif %}
                             </div>
@@ -164,10 +164,10 @@
             <div class="text-center">
                 {% if receipt.venmo_username %}
                 <a id="venmo-pay-link"
-                   href="https://venmo.com/{{ receipt.venmo_username }}?txn=pay&amount={{ my_total|floatformat:2 }}&note=You%20Owe%20-%20{{ receipt.restaurant_name|urlencode }}%20{{ share_url }}"
+                   href="https://venmo.com/{{ receipt.venmo_username }}?txn=pay&amount={{ my_total|floatformat:2 }}&note=You%20Owe%20-%20{{ receipt.restaurant_name|urlencode:"" }}%20{{ share_url|urlencode:"" }}"
                    target="_blank"
                    rel="noopener noreferrer"
-                   class="inline-flex items-center px-4 py-2 bg-[#008CFF] text-white rounded-lg text-sm font-medium hover:bg-[#0070CC] transition-colors">
+                   class="inline-flex items-center px-4 py-3 bg-[#008CFF] text-white rounded-lg text-sm font-medium hover:bg-[#0070CC] transition-colors">
                     Pay @{{ receipt.venmo_username }} ${{ my_total|floatformat:2 }}
                 </a>
                 {% else %}

--- a/test/js/fully-claimed-styling.spec.js
+++ b/test/js/fully-claimed-styling.spec.js
@@ -47,7 +47,7 @@ describe('Fully Claimed Items - Consistent Styling', () => {
   });
 
   describe('All fully claimed scenarios should have consistent disabled styling', () => {
-    const expectedDisabledClasses = 'claim-quantity w-12 h-8 px-2 py-1 border rounded-lg text-center tabular-nums border-gray-200 bg-gray-50 text-gray-600';
+    const expectedDisabledClasses = 'claim-quantity w-12 h-11 px-2 py-1 border rounded-lg text-center tabular-nums border-gray-200 bg-gray-50 text-gray-600';
     const expectedContainerOpacity = 'opacity-50';
 
     it('should show disabled input when item is fully claimed by others', () => {
@@ -176,7 +176,7 @@ describe('Fully Claimed Items - Consistent Styling', () => {
 
       // Assert: Should show ENABLED input
       expect(input).toBeTruthy();
-      expect(input.className).toBe('claim-quantity w-12 h-8 px-2 py-1 border rounded-lg text-center tabular-nums border-gray-300 focus:ring-2 focus:ring-blue-500');
+      expect(input.className).toBe('claim-quantity w-12 h-11 px-2 py-1 border rounded-lg text-center tabular-nums border-gray-300 focus:ring-2 focus:ring-blue-500');
       expect(input.disabled).toBe(false);
       expect(input.readOnly).toBe(false);
       
@@ -209,7 +209,7 @@ describe('Fully Claimed Items - Consistent Styling', () => {
 
       // Assert: Should show ENABLED input
       expect(input).toBeTruthy();
-      expect(input.className).toBe('claim-quantity w-12 h-8 px-2 py-1 border rounded-lg text-center tabular-nums border-gray-300 focus:ring-2 focus:ring-blue-500');
+      expect(input.className).toBe('claim-quantity w-12 h-11 px-2 py-1 border rounded-lg text-center tabular-nums border-gray-300 focus:ring-2 focus:ring-blue-500');
       expect(input.disabled).toBe(false);
       expect(input.readOnly).toBe(false);
       expect(input.value).toBe('1'); // Shows existing claim
@@ -226,7 +226,7 @@ describe('Fully Claimed Items - Consistent Styling', () => {
             <div class="flex items-center space-x-2">
               <label class="text-sm text-gray-600">Claim:</label>
               <input type="number" 
-                     class="claim-quantity w-12 h-8 px-2 py-1 border border-gray-300 rounded-lg text-center tabular-nums"
+                     class="claim-quantity w-12 h-11 px-2 py-1 border border-gray-300 rounded-lg text-center tabular-nums"
                      value="0"
                      data-item-id="600">
             </div>

--- a/test/js/view-page.spec.js
+++ b/test/js/view-page.spec.js
@@ -471,7 +471,7 @@ describe('View Page Claiming Functionality', () => {
           <div class="item-share-amount" data-amount="15.50"></div>
           <div class="ml-4">
             <div class="flex items-center space-x-2">
-              <input type="number" class="claim-quantity w-12 h-8 px-2 py-1 border border-gray-300 rounded-lg text-center tabular-nums"
+              <input type="number" class="claim-quantity w-12 h-11 px-2 py-1 border border-gray-300 rounded-lg text-center tabular-nums"
                      min="0" max="2" value="0" data-item-id="1">
               <span class="text-sm text-gray-600">of 2</span>
             </div>
@@ -744,11 +744,11 @@ describe('View Page Claiming Functionality', () => {
         
         // Enabled input should use gray-300 border
         const enabledClasses = getClaimInputClasses(false);
-        expect(enabledClasses).toBe('claim-quantity w-12 h-8 px-2 py-1 border rounded-lg text-center tabular-nums border-gray-300 focus:ring-2 focus:ring-blue-500');
+        expect(enabledClasses).toBe('claim-quantity w-12 h-11 px-2 py-1 border rounded-lg text-center tabular-nums border-gray-300 focus:ring-2 focus:ring-blue-500');
         
         // Disabled input should use gray-200 border and gray-50 background
         const disabledClasses = getClaimInputClasses(true);
-        expect(disabledClasses).toBe('claim-quantity w-12 h-8 px-2 py-1 border rounded-lg text-center tabular-nums border-gray-200 bg-gray-50 text-gray-600');
+        expect(disabledClasses).toBe('claim-quantity w-12 h-11 px-2 py-1 border rounded-lg text-center tabular-nums border-gray-200 bg-gray-50 text-gray-600');
         
         // Test in actual DOM update scenario
         setBodyHTML(`
@@ -774,7 +774,7 @@ describe('View Page Claiming Functionality', () => {
         const input = document.querySelector('.claim-quantity[data-item-id="1"]');
         expect(input).toBeTruthy();
         expect(input.disabled).toBe(true);
-        expect(input.className).toBe('claim-quantity w-12 h-8 px-2 py-1 border rounded-lg text-center tabular-nums border-gray-200 bg-gray-50 text-gray-600');
+        expect(input.className).toBe('claim-quantity w-12 h-11 px-2 py-1 border rounded-lg text-center tabular-nums border-gray-200 bg-gray-50 text-gray-600');
       });
 
       it('should maintain consistent disabled input styling between server and real-time updates', () => {


### PR DESCRIPTION
## Summary

Two mobile-facing bugfixes, both diagnosed and verified locally with Playwright (iPhone viewport) plus full backend (182) and JS (200) test suites.

### 1. Literal `+` / `&amp;` in Venmo links and displays
- **Root cause**: `InputValidator` stored bleach-escaped text (`&` → `&amp;`) in the DB, so Django autoescape double-escaped on render and entities leaked into Venmo note params. New `strip_html_tags()` helper applies `html.unescape()` after `bleach.clean(tags=[], strip=True)` — raw text in DB, template autoescape stays the single XSS defense (existing `test_javascript_security` asserts this).
- Venmo notes now percent-encoded **exactly once**: JS `updateVenmoLink` encodes the whole note with `encodeURIComponent` (raw spaces previously got form-re-encoded to literal `+` by Venmo's redirect); template hrefs use `|urlencode:""` on restaurant name and share URL.
- Verified with restaurant `Tom & Jerry's Café + Bar` and item names containing `&`/quotes: pay + charge links decode cleanly, no double-escape patterns anywhere in the page.

### 2. iOS tap targets & focus-zoom on the claim page
- Subdivide/stepper buttons were 32×32px (iOS minimum is 44px); Venmo charge pill was 20px tall. New `.tap-target` CSS utility guarantees a ≥44×44px effective hit area via a transparent `::after` box so visuals stay tight; buttons upsized 32→40px visual. Inputs (which can't render pseudo-elements) get a real 44px height (`h-11`); form controls move to `py-2.5`/`py-3`.
- Edit-page number inputs `text-sm` → `text-base` (16px) so iOS no longer zooms on input focus. No viewport-meta zoom disabling (accessibility preserved).
- Measured programmatically at 390×844: every interactive element ≥44px effective, every input ≥16px font, no horizontal overflow; desktop layout unchanged structurally.

**Note**: receipts created before this fix retain escaped entities until their 30-day expiry (no data migration — data is ephemeral by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2p3Wece4UCgTHHogmUd5V