### PR TITLE
Exact cent allocation for claim totals; fix review-app fly CLI calls

### DIFF
--- a/.github/workflows/fly-cleanup.yml
+++ b/.github/workflows/fly-cleanup.yml
@@ -1,0 +1,42 @@
+name: Cleanup Orphaned Review Apps
+# Destroys Fly review apps (pr-N-kuitang-receipt-splitter and their -db
+# postgres apps) whose PR is closed. The close-time cleanup in
+# fly-review.yml silently failed for a while (`fly` vs `flyctl`), so
+# orphaned -db apps can linger. Run manually from the Actions tab.
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List what would be destroyed without destroying"
+        type: boolean
+        default: true
+
+env:
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Destroy review apps for closed PRs
+        run: |
+          set -euo pipefail
+          DRY_RUN="${{ inputs.dry_run }}"
+          REPO="${{ github.repository }}"
+
+          flyctl apps list --json | jq -r '.[].Name' | grep -E '^pr-[0-9]+-kuitang-receipt-splitter(-db)?$' | while read -r APP; do
+            PR_NUM=$(echo "$APP" | sed -E 's/^pr-([0-9]+)-.*/\1/')
+            STATE=$(gh pr view "$PR_NUM" --repo "$REPO" --json state --jq .state 2>/dev/null || echo "UNKNOWN")
+            if [ "$STATE" = "OPEN" ]; then
+              echo "SKIP  $APP (PR #$PR_NUM is open)"
+            elif [ "$DRY_RUN" = "true" ]; then
+              echo "WOULD DESTROY  $APP (PR #$PR_NUM state: $STATE)"
+            else
+              echo "DESTROY  $APP (PR #$PR_NUM state: $STATE)"
+              flyctl apps destroy "$APP" --yes || echo "Failed to destroy $APP"
+            fi
+          done
+          echo "Done."

--- a/.github/workflows/fly-review.yml
+++ b/.github/workflows/fly-review.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           APP_NAME="pr-${{ github.event.number }}-${{ github.repository_owner }}-${{ github.event.repository.name }}"
           echo "Allocating shared IPv4 for app: $APP_NAME"
-          fly ips allocate-v4 --shared -a "$APP_NAME" || echo "IPv4 allocation failed or already exists"
+          flyctl ips allocate-v4 --shared -a "$APP_NAME" || echo "IPv4 allocation failed or already exists"
 
       - name: Destroy preview database resources
         if: github.event.action == 'closed'
@@ -53,28 +53,28 @@ jobs:
           DB_APP_NAME="${APP_NAME}-db"
           echo "Cleaning up database app: $DB_APP_NAME"
 
-          if fly apps info "$DB_APP_NAME" > /dev/null 2>&1; then
-            MACHINE_IDS=$(fly machines list -a "$DB_APP_NAME" --json | jq -r '.[].id')
+          if flyctl apps info "$DB_APP_NAME" > /dev/null 2>&1; then
+            MACHINE_IDS=$(flyctl machines list -a "$DB_APP_NAME" --json | jq -r '.[].id')
             if [ -n "$MACHINE_IDS" ]; then
               for MACHINE_ID in $MACHINE_IDS; do
                 echo "Destroying database machine $MACHINE_ID"
-                fly machines destroy "$MACHINE_ID" -a "$DB_APP_NAME" --force || echo "Failed to destroy machine $MACHINE_ID"
+                flyctl machines destroy "$MACHINE_ID" -a "$DB_APP_NAME" --force || echo "Failed to destroy machine $MACHINE_ID"
               done
             else
               echo "No machines found for $DB_APP_NAME"
             fi
 
-            VOLUME_IDS=$(fly volumes list -a "$DB_APP_NAME" --json | jq -r '.[]?.id')
+            VOLUME_IDS=$(flyctl volumes list -a "$DB_APP_NAME" --json | jq -r '.[]?.id')
             if [ -n "$VOLUME_IDS" ]; then
               for VOLUME_ID in $VOLUME_IDS; do
                 echo "Destroying database volume $VOLUME_ID"
-                fly volumes destroy "$VOLUME_ID" -a "$DB_APP_NAME" --yes || echo "Failed to destroy volume $VOLUME_ID"
+                flyctl volumes destroy "$VOLUME_ID" -a "$DB_APP_NAME" --yes || echo "Failed to destroy volume $VOLUME_ID"
               done
             else
               echo "No volumes found for $DB_APP_NAME"
             fi
 
-            fly apps destroy "$DB_APP_NAME" --yes || echo "Failed to destroy database app $DB_APP_NAME"
+            flyctl apps destroy "$DB_APP_NAME" --yes || echo "Failed to destroy database app $DB_APP_NAME"
           else
             echo "Database app $DB_APP_NAME does not exist, skipping."
           fi

--- a/receipts/services/claim_service.py
+++ b/receipts/services/claim_service.py
@@ -4,7 +4,6 @@ Encapsulates all business logic related to claims
 """
 from typing import Dict, Optional, List, Tuple
 from decimal import Decimal
-from fractions import Fraction
 from math import gcd
 from django.utils import timezone
 from django.core.exceptions import ValidationError
@@ -12,8 +11,9 @@ from django.core.cache import cache
 from django.db import transaction
 
 from receipts.models import Claim, LineItem, Receipt
-from django.db.models import QuerySet, Sum, F, DecimalField, FloatField, Prefetch, Q, Value
-from django.db.models.functions import Coalesce, Cast
+from django.db.models import QuerySet, Sum, Q, Value
+from django.db.models.functions import Coalesce
+from receipts.services.money import compute_receipt_split
 from receipts.services.validation_pipeline import ValidationPipeline
 from receipts.middleware.query_monitor import log_query_performance
 
@@ -172,17 +172,10 @@ class ClaimService:
         cache.delete(f"participant_totals:{receipt_id}")
         cache.delete(f"receipt_view:{receipt_id}")
 
-        # Calculate my_total: share = (claim_num / item_num) * total_share
-        my_total = Decimal('0')
-        for claim in created_claims:
-            line_item = locked_items_dict.get(str(claim.line_item_id))
-            if line_item and line_item.quantity_numerator > 0:
-                share_fraction = Fraction(claim.quantity_numerator, line_item.quantity_numerator)
-                total_share = line_item.total_price + line_item.prorated_tax + line_item.prorated_tip
-                my_total += Decimal(share_fraction.numerator) / Decimal(share_fraction.denominator) * total_share
-
-        # Get participant totals
+        # Get participant totals (exact cent allocation); my_total comes from
+        # the same allocation so it always matches the participant row
         participant_totals = self.get_participant_totals(receipt_id)
+        my_total = participant_totals.get(claimer_name, Decimal('0'))
 
         return {
             'success': True,
@@ -484,26 +477,17 @@ class ClaimService:
             return None
     
     def _get_participant_totals(self, receipt_id: str) -> Dict[str, Decimal]:
-        """Calculate totals per participant. share = claim_num / item_num * total_share"""
-        if not Receipt.objects.filter(id=receipt_id).exists():
+        """Calculate totals per participant with exact cent allocation.
+
+        Shares are computed exactly (claim_num / item_num * total_share) and
+        rounded once at the receipt level so totals always sum to receipt.total.
+        """
+        try:
+            receipt = Receipt.objects.prefetch_related('items__claims').get(id=receipt_id)
+        except Receipt.DoesNotExist:
             return {}
 
-        # Cast to FloatField to force float division in SQLite (avoids integer truncation)
-        results = Claim.objects.filter(
-            line_item__receipt_id=receipt_id
-        ).values('claimer_name').annotate(
-            total=Sum(
-                (Cast(F('quantity_numerator'), FloatField())
-                 / Cast(F('line_item__quantity_numerator'), FloatField()))
-                * (F('line_item__total_price') + F('line_item__prorated_tax') + F('line_item__prorated_tip')),
-                output_field=DecimalField(max_digits=12, decimal_places=6)
-            )
-        ).order_by('claimer_name')
-
-        return {
-            result['claimer_name']: result['total'] or Decimal('0')
-            for result in results
-        }
+        return compute_receipt_split(receipt)['participant_totals']
     
     def _count_claimed_numerator(self, line_item_id: str) -> int:
         """Get total claimed numerator for a line item (shared denominator)."""

--- a/receipts/services/money.py
+++ b/receipts/services/money.py
@@ -1,0 +1,116 @@
+"""
+Exact money splitting for claims.
+
+Per-claim shares are computed exactly with Fraction and rounded to whole
+cents only once, at the receipt-level aggregation boundary, using
+largest-remainder cent allocation. This guarantees:
+- participant totals + unclaimed == receipt.total exactly
+- no participant drifts more than a cent from their exact share
+- a fully-claimed receipt (by quantity) has exactly 0 unclaimed
+
+Rounding per claim/portion and summing (the old approach) diverges from the
+receipt total by sub-cent residue because prorated tax/tip are quantized to
+6 decimal places per item.
+"""
+from decimal import Decimal, ROUND_HALF_UP
+from fractions import Fraction
+from math import floor
+from typing import Dict, List, Tuple
+
+CENT = Decimal('0.01')
+
+# Dict key used internally for the unclaimed remainder during allocation
+_UNCLAIMED = object()
+
+
+def compute_receipt_split(receipt) -> Dict:
+    """Compute exact-to-the-cent claim totals for a receipt.
+
+    Works entirely from prefetched receipt.items / item.claims (no queries).
+
+    Returns a dict with:
+    - participant_totals: {claimer_name: Decimal} in whole cents
+    - total_claimed / total_unclaimed: Decimals summing exactly to receipt.total
+    - is_fully_claimed: quantity-based flag (every numerator unit of every
+      item is claimed) — the true "everything is claimed" semantic, immune
+      to rounding residue
+    """
+    exact_totals: Dict[str, Fraction] = {}
+    is_fully_claimed = True
+    has_items = False
+
+    for item in receipt.items.all():
+        has_items = True
+        item_share = Fraction(item.get_total_share())
+        claimed_num = 0
+        for claim in item.claims.all():
+            claimed_num += claim.quantity_numerator
+            if item.quantity_numerator > 0:
+                share = Fraction(claim.quantity_numerator, item.quantity_numerator) * item_share
+                exact_totals[claim.claimer_name] = exact_totals.get(claim.claimer_name, Fraction(0)) + share
+        if claimed_num < item.quantity_numerator:
+            is_fully_claimed = False
+
+    if not has_items or not exact_totals:
+        is_fully_claimed = False
+
+    if not exact_totals:
+        return {
+            'participant_totals': {},
+            'total_claimed': Decimal('0.00'),
+            'total_unclaimed': receipt.total.quantize(CENT),
+            'is_fully_claimed': False,
+        }
+
+    # The unclaimed remainder competes for cents like a participant, so
+    # everything always sums exactly to the receipt total. A fully-claimed
+    # receipt leaves only sub-cent residue here, which allocates to 0 cents.
+    entries = list(exact_totals.items())
+    unclaimed_exact = Fraction(receipt.total) - sum(exact_totals.values())
+    entries.append((_UNCLAIMED, unclaimed_exact))
+
+    allocated = allocate_cents(entries, receipt.total)
+    total_unclaimed = allocated.pop(_UNCLAIMED, Decimal('0.00'))
+    total_claimed = receipt.total.quantize(CENT) - total_unclaimed
+
+    return {
+        'participant_totals': allocated,
+        'total_claimed': total_claimed,
+        'total_unclaimed': total_unclaimed,
+        'is_fully_claimed': is_fully_claimed,
+    }
+
+
+def allocate_cents(entries: List[Tuple[object, Fraction]], total: Decimal) -> Dict[object, Decimal]:
+    """Allocate `total` in whole cents across exact Fraction amounts.
+
+    Largest-remainder method: floor everything to cents, then hand out the
+    remaining cents to the largest fractional remainders. The result always
+    sums exactly to `total` (rounded to the cent).
+    """
+    total_cents = int((total * 100).to_integral_value(rounding=ROUND_HALF_UP))
+
+    allocations = []  # [key, cents, remainder]
+    for key, amount in entries:
+        cents = amount * 100
+        base = floor(cents)
+        allocations.append([key, base, cents - base])
+
+    leftover = total_cents - sum(a[1] for a in allocations)
+
+    # Distribute leftover cents, largest fractional remainder first
+    # (stable: ties broken by original entry order)
+    by_remainder = sorted(range(len(allocations)), key=lambda i: (-allocations[i][2], i))
+    i = 0
+    while leftover > 0:
+        allocations[by_remainder[i % len(allocations)]][1] += 1
+        leftover -= 1
+        i += 1
+    # Defensive: floors can only undershoot, but never leave anyone short
+    # more than a cent if this ever runs.
+    while leftover < 0:
+        allocations[by_remainder[len(allocations) - 1 - (i % len(allocations))]][1] -= 1
+        leftover += 1
+        i += 1
+
+    return {key: (Decimal(cents) / 100).quantize(CENT) for key, cents, _ in allocations}

--- a/receipts/services/receipt_service.py
+++ b/receipts/services/receipt_service.py
@@ -11,10 +11,10 @@ from django.core.exceptions import ValidationError
 from django.core.signing import Signer, BadSignature
 from django.core.cache import cache
 from django.db import transaction
-from django.db.models import QuerySet, Prefetch, Sum, F, DecimalField, FloatField
-from django.db.models.functions import Cast
+from django.db.models import Prefetch
 
 from receipts.models import Receipt, LineItem, ActiveViewer, Claim
+from receipts.services.money import compute_receipt_split
 from receipts.services.validation_pipeline import ValidationPipeline
 from receipts.async_processor import (
     process_receipt_async,
@@ -240,13 +240,13 @@ class ReceiptService:
                 'available_quantity': available_quantity
             })
         
-        # Calculate participant totals
-        participant_totals = self._get_participant_totals(receipt_id)
-        
-        # Calculate summary
-        total_claimed = sum(participant_totals.values())
-        total_unclaimed = receipt.total - total_claimed
-        
+        # Calculate participant totals with exact cent allocation so that
+        # participant totals + unclaimed always equal receipt.total exactly
+        split = compute_receipt_split(receipt)
+        participant_totals = split['participant_totals']
+        total_claimed = split['total_claimed']
+        total_unclaimed = split['total_unclaimed']
+
         # Build name→venmo map from prefetched viewers
         viewer_venmo_map = {
             v.viewer_name: v.venmo_username
@@ -266,7 +266,8 @@ class ReceiptService:
             'items_with_claims': items_with_claims,
             'participant_totals': participant_list,
             'total_claimed': total_claimed,
-            'total_unclaimed': total_unclaimed
+            'total_unclaimed': total_unclaimed,
+            'is_fully_claimed': split['is_fully_claimed']
         }
         
         # Cache if finalized (30 minutes)
@@ -455,31 +456,6 @@ class ReceiptService:
                 }
                 for item in receipt.items.all()
             ]
-        }
-    
-    def _get_participant_totals(self, receipt_id: str) -> Dict[str, Decimal]:
-        """Calculate totals per participant efficiently using single database query.
-
-        Share = (claim.numerator / item.numerator) * (item.total + item.tax + item.tip)
-        """
-        if not Receipt.objects.filter(id=receipt_id).exists():
-            return {}
-
-        # Cast to FloatField to force float division in SQLite (avoids integer truncation)
-        results = Claim.objects.filter(
-            line_item__receipt_id=receipt_id
-        ).values('claimer_name').annotate(
-            total=Sum(
-                (Cast(F('quantity_numerator'), FloatField())
-                 / Cast(F('line_item__quantity_numerator'), FloatField()))
-                * (F('line_item__total_price') + F('line_item__prorated_tax') + F('line_item__prorated_tip')),
-                output_field=DecimalField(max_digits=12, decimal_places=6)
-            )
-        ).order_by('claimer_name')
-
-        return {
-            result['claimer_name']: result['total'] or Decimal('0')
-            for result in results
         }
     
     def _get_all_claimer_names(self, receipt_id: str) -> List[str]:

--- a/receipts/test_claim_totals.py
+++ b/receipts/test_claim_totals.py
@@ -10,7 +10,7 @@ from decimal import Decimal
 import json
 
 from receipts.models import Receipt, LineItem, Claim
-from receipts.services import ClaimService
+from receipts.services import ClaimService, ReceiptService
 
 
 class ClaimTotalsByNameRepositoryTests(TestCase):
@@ -362,8 +362,192 @@ class ClaimTotalsIntegrationTests(TestCase):
         
         service = ClaimService()
         participant_totals = service.get_participant_totals(self.receipt.id)
-        
+
         # John should have total from both sessions
         self.assertEqual(participant_totals["John"], Decimal("22.88"))
         # Jane should have her total
         self.assertEqual(participant_totals["Jane"], Decimal("5.20"))
+
+
+class RoundingResidueTests(TestCase):
+    """Sub-cent rounding residue must not break the fully-claimed state.
+
+    Regression: a fully-claimed receipt showed "Not Claimed $0.00" and never
+    showed the success state, because per-item prorations are quantized to
+    6 decimal places so summing per-claim shares diverges from receipt.total
+    by sub-cent amounts (positive or negative).
+    """
+
+    def setUp(self):
+        self.receipt_service = ReceiptService()
+
+    def _make_receipt(self, tip):
+        """3 items at $10.00 with prorations computed exactly as production does.
+
+        With tip=1.00 each prorated tip is 1/3 = 0.333333 (6dp), so the sum
+        of shares is 0.000001 BELOW the receipt total (positive residue).
+        With tip=2.00 each prorated tip is 0.666667, so the sum of shares is
+        0.000001 ABOVE the receipt total (negative residue).
+        """
+        receipt = Receipt.objects.create(
+            uploader_name="Uploader",
+            restaurant_name="Residue Cafe",
+            date=timezone.now(),
+            subtotal=Decimal("30.00"),
+            tax=Decimal("1.23"),
+            tip=tip,
+            total=Decimal("30.00") + Decimal("1.23") + tip,
+            is_finalized=True
+        )
+        items = []
+        for i in range(3):
+            item = LineItem(
+                receipt=receipt,
+                name=f"Dish {i + 1}",
+                quantity_numerator=1,
+                unit_price=Decimal("10.00"),
+                total_price=Decimal("10.00"),
+            )
+            item.calculate_prorations()
+            item.save()
+            items.append(item)
+        return receipt, items
+
+    def _claim_all(self, items, names):
+        for item, name in zip(items, names):
+            Claim.objects.create(
+                line_item=item,
+                claimer_name=name,
+                quantity_numerator=item.quantity_numerator,
+                session_id=f"session-{name}",
+                is_finalized=True,
+            )
+
+    def _assert_fully_claimed_invariants(self, receipt):
+        data = self.receipt_service.get_receipt_for_viewing_by_slug(receipt.slug)
+
+        # Fully claimed: no unclaimed residue, quantity-based flag set
+        self.assertEqual(data['total_unclaimed'], Decimal('0'))
+        self.assertTrue(data['is_fully_claimed'])
+
+        # Money adds up exactly: participants sum to the receipt total
+        participant_sum = sum(p['amount'] for p in data['participant_totals'])
+        self.assertEqual(participant_sum, receipt.total)
+        self.assertEqual(data['total_claimed'], receipt.total)
+
+        # Every displayed amount is a whole number of cents
+        for p in data['participant_totals']:
+            self.assertEqual(p['amount'], p['amount'].quantize(Decimal('0.01')))
+        return data
+
+    def test_fully_claimed_positive_residue(self):
+        """Sum of rounded shares below total: no 'Not Claimed $0.00' row"""
+        receipt, items = self._make_receipt(tip=Decimal("1.00"))
+        self._claim_all(items, ["Alice", "Bob", "Carol"])
+        self._assert_fully_claimed_invariants(receipt)
+
+    def test_fully_claimed_negative_residue(self):
+        """Sum of rounded shares above total: total_unclaimed must not go negative"""
+        receipt, items = self._make_receipt(tip=Decimal("2.00"))
+        self._claim_all(items, ["Alice", "Bob", "Carol"])
+        self._assert_fully_claimed_invariants(receipt)
+
+    def test_fully_claimed_subdivided_item(self):
+        """A subdivided item claimed in thirds still balances exactly"""
+        receipt = Receipt.objects.create(
+            uploader_name="Uploader",
+            restaurant_name="Split Bar",
+            date=timezone.now(),
+            subtotal=Decimal("10.00"),
+            tax=Decimal("1.00"),
+            tip=Decimal("2.00"),
+            total=Decimal("13.00"),
+            is_finalized=True
+        )
+        item = LineItem(
+            receipt=receipt,
+            name="Shared Platter",
+            quantity_numerator=3,
+            quantity_denominator=3,
+            unit_price=Decimal("10.00"),
+            total_price=Decimal("10.00"),
+        )
+        item.calculate_prorations()
+        item.save()
+        # 13.00 / 3 = 4.3333... per portion: cannot round evenly
+        for name in ["Alice", "Bob", "Carol"]:
+            Claim.objects.create(
+                line_item=item,
+                claimer_name=name,
+                quantity_numerator=1,
+                session_id=f"session-{name}",
+                is_finalized=True,
+            )
+        data = self._assert_fully_claimed_invariants(receipt)
+        # No one drifts more than a cent from their exact share (13/3)
+        for p in data['participant_totals']:
+            self.assertLess(abs(p['amount'] - Decimal("13.00") / 3), Decimal("0.01"))
+
+    def test_many_items_fully_claimed_by_three(self):
+        """Production-like: 19 items, three claimers, awkward prices"""
+        prices = [Decimal(p) for p in (
+            "12.34", "9.99", "23.45", "7.77", "15.00", "8.13", "19.87",
+            "11.11", "6.66", "14.29", "22.22", "5.55", "18.18", "9.09",
+            "13.13", "17.71", "21.12", "10.01", "45.13"
+        )]
+        subtotal = sum(prices)
+        tax = Decimal("25.71")
+        tip = Decimal("58.30")
+        receipt = Receipt.objects.create(
+            uploader_name="Uploader",
+            restaurant_name="Big Night Out",
+            date=timezone.now(),
+            subtotal=subtotal,
+            tax=tax,
+            tip=tip,
+            total=subtotal + tax + tip,
+            is_finalized=True
+        )
+        items = []
+        for i, price in enumerate(prices):
+            item = LineItem(
+                receipt=receipt,
+                name=f"Item {i + 1}",
+                quantity_numerator=1,
+                unit_price=price,
+                total_price=price,
+            )
+            item.calculate_prorations()
+            item.save()
+            items.append(item)
+        names = ["Alice", "Bob", "Carol"]
+        self._claim_all(items, [names[i % 3] for i in range(len(items))])
+        self._assert_fully_claimed_invariants(receipt)
+
+    def test_partially_claimed_receipt_shows_unclaimed(self):
+        """Partially claimed receipts still report a correct unclaimed amount"""
+        receipt, items = self._make_receipt(tip=Decimal("1.00"))
+        # Only claim the first two items
+        self._claim_all(items[:2], ["Alice", "Bob"])
+
+        data = self.receipt_service.get_receipt_for_viewing_by_slug(receipt.slug)
+
+        self.assertFalse(data['is_fully_claimed'])
+        self.assertGreater(data['total_unclaimed'], Decimal('0'))
+        # Unclaimed is the third item's share (~10.74) to the cent
+        third_share = items[2].get_total_share()
+        self.assertLess(abs(data['total_unclaimed'] - third_share), Decimal("0.01"))
+        # Claimed + unclaimed must equal the receipt total exactly
+        participant_sum = sum(p['amount'] for p in data['participant_totals'])
+        self.assertEqual(participant_sum + data['total_unclaimed'], receipt.total)
+        self.assertEqual(data['total_claimed'] + data['total_unclaimed'], receipt.total)
+
+    def test_unclaimed_receipt_reports_full_total(self):
+        """No claims at all: everything is unclaimed"""
+        receipt, items = self._make_receipt(tip=Decimal("1.00"))
+
+        data = self.receipt_service.get_receipt_for_viewing_by_slug(receipt.slug)
+
+        self.assertFalse(data['is_fully_claimed'])
+        self.assertEqual(data['total_unclaimed'], receipt.total)
+        self.assertEqual(data['total_claimed'], Decimal('0'))

--- a/receipts/tests.py
+++ b/receipts/tests.py
@@ -218,8 +218,9 @@ class ViewTests(TestCase):
         
         # Check that the per-item share is calculated and displayed
         # Total share is 20.00 + 2.00 + 3.00 = 25.00 for all 2 items
-        # Per item: 25.00 / 2 = 12.50
-        self.assertContains(response, 'data-amount="12.50"')
+        # Per item: 25.00 / 2 = 12.50 (data-amount keeps full precision so
+        # the JS rounds only once, at the final total)
+        self.assertContains(response, 'data-amount="12.500000"')
         self.assertContains(response, '$12.50</span>')
     
     def test_view_nonexistent_receipt(self):
@@ -370,13 +371,13 @@ class ViewTests(TestCase):
         response = self.client.post(url, {'viewer_name': 'Test Viewer'})
         
         # Item 1: 20.00 + (40% of 5.00 tax) + (40% of 10.00 tip) = 20 + 2 + 4 = 26.00 total
-        # Per item: 26.00 / 2 = 13.00
-        self.assertContains(response, 'data-amount="13.00"')
+        # Per item: 26.00 / 2 = 13.00 (data-amount keeps full precision)
+        self.assertContains(response, 'data-amount="13.000000"')
         self.assertContains(response, '$13.00</span>')
-        
+
         # Item 2: 30.00 + (60% of 5.00 tax) + (60% of 10.00 tip) = 30 + 3 + 6 = 39.00 total
         # Per item: 39.00 / 3 = 13.00
-        self.assertContains(response, 'data-amount="13.00"')
+        self.assertContains(response, 'data-amount="13.000000"')
         self.assertContains(response, '$13.00</span>')
     
     def test_participant_totals_display(self):

--- a/receipts/views.py
+++ b/receipts/views.py
@@ -275,7 +275,7 @@ def view_receipt(request, receipt_slug):
         my_total = Decimal('0')
         my_claims_by_item = {}  # Map item_id -> quantity_claimed
         is_user_finalized = False
-        
+
         if viewer_name:
             # Extract claims from prefetched data instead of making 3 separate queries
             for item_data in receipt_data['items_with_claims']:
@@ -284,13 +284,14 @@ def view_receipt(request, receipt_slug):
                     if claim.claimer_name == viewer_name:
                         my_claims.append(claim)
                         my_claims_by_item[str(item.id)] = claim.quantity_numerator
-                        # Share = (claim_num / item_num) * total_share
-                        if item.quantity_numerator > 0:
-                            from fractions import Fraction
-                            share_fraction = Fraction(claim.quantity_numerator, item.quantity_numerator)
-                            my_total += (Decimal(share_fraction.numerator) / Decimal(share_fraction.denominator)) * item.get_total_share()
                         if claim.is_finalized:
                             is_user_finalized = True
+            # Use the cent-allocated participant totals so the displayed
+            # (and Venmo'd) amount matches the participant row exactly
+            for participant in receipt_data['participant_totals']:
+                if participant['name'] == viewer_name:
+                    my_total = participant['amount']
+                    break
         
         # Add user's existing claims to items_with_claims data
         for item_data in receipt_data['items_with_claims']:
@@ -311,9 +312,10 @@ def view_receipt(request, receipt_slug):
             'participant_totals': receipt_data['participant_totals'],
             'total_claimed': receipt_data['total_claimed'],
             'total_unclaimed': receipt_data['total_unclaimed'],
+            'is_fully_claimed': receipt_data['is_fully_claimed'],
             'share_url': request.build_absolute_uri(receipt.get_absolute_url())
         }
-        
+
         return render(request, 'receipts/view.html', context)
         
     except ReceiptNotFoundError:
@@ -479,20 +481,21 @@ def get_claim_status(request, receipt_slug):
             viewer_name = receipt.uploader_name
         
         # Calculate user's total from prefetched data (no extra queries!)
+        # Uses the cent-allocated participant totals so it matches the
+        # participant row and the server-rendered page exactly
         my_total = Decimal('0')
         is_user_finalized = False
         if viewer_name:
-            from fractions import Fraction
+            for participant in receipt_data['participant_totals']:
+                if participant['name'] == viewer_name:
+                    my_total = participant['amount']
+                    break
             for item_data in receipt_data['items_with_claims']:
-                item = item_data['item']
                 for claim in item_data['claims']:
-                    if claim.claimer_name == viewer_name:
-                        if item.quantity_numerator > 0:
-                            share_fraction = Fraction(claim.quantity_numerator, item.quantity_numerator)
-                            my_total += (Decimal(share_fraction.numerator) / Decimal(share_fraction.denominator)) * item.get_total_share()
-                        if claim.is_finalized and claim.session_id == user_context.session_id:
-                            is_user_finalized = True
-        
+                    if (claim.claimer_name == viewer_name and claim.is_finalized
+                            and claim.session_id == user_context.session_id):
+                        is_user_finalized = True
+
         # Prepare response data
         response_data = {
             'success': True,
@@ -505,6 +508,7 @@ def get_claim_status(request, receipt_slug):
             ],
             'total_claimed': float(receipt_data['total_claimed']),
             'total_unclaimed': float(receipt_data['total_unclaimed']),
+            'is_fully_claimed': receipt_data['is_fully_claimed'],
             'my_total': float(my_total),
             'items_with_claims': []
         }

--- a/static/js/view-page.js
+++ b/static/js/view-page.js
@@ -524,13 +524,14 @@ function updateItemClaims(itemsWithClaims, viewerName = null, isFinalized = fals
             }
         }
 
-        // Update per-portion share display and data attribute
+        // Update per-portion share display and data attribute.
+        // data-amount keeps full precision (rounding happens once, on the
+        // final total) while the visible text is rounded to cents.
         if (itemData.per_portion_share != null) {
             const shareEl = itemContainer.querySelector('.item-share-amount');
             if (shareEl) {
-                const share = itemData.per_portion_share.toFixed(2);
-                shareEl.dataset.amount = share;
-                shareEl.textContent = `$${share}`;
+                shareEl.dataset.amount = String(itemData.per_portion_share);
+                shareEl.textContent = `$${itemData.per_portion_share.toFixed(2)}`;
             }
             // Update the "per item/part" line
             const calcLine = itemContainer.querySelector('.text-gray-500.text-xs');
@@ -539,9 +540,8 @@ function updateItemClaims(itemsWithClaims, viewerName = null, isFinalized = fals
                 const suffix = den > 1 ? 'part' : 'item';
                 const shareSpan = calcLine.querySelector('.item-share-amount');
                 if (shareSpan) {
-                    const share = itemData.per_portion_share.toFixed(2);
-                    shareSpan.dataset.amount = share;
-                    shareSpan.textContent = `$${share}`;
+                    shareSpan.dataset.amount = String(itemData.per_portion_share);
+                    shareSpan.textContent = `$${itemData.per_portion_share.toFixed(2)}`;
                 }
                 // Update suffix text (part vs item)
                 const lastText = calcLine.lastChild;

--- a/templates/receipts/partials/item_row_display.html
+++ b/templates/receipts/partials/item_row_display.html
@@ -36,7 +36,7 @@ Context: item (LineItem), show_calculations, show_claims, claims, viewer_name, r
     
     {% if show_calculations %}
     <div class="mt-1">
-        <p class="text-gray-500 text-xs">+ Tax: ${{ item.prorated_tax|floatformat:2 }} + Tip: ${{ item.prorated_tip|floatformat:2 }} = <span class="font-semibold item-share-amount" data-amount="{{ item.get_per_portion_share|floatformat:2 }}">${{ item.get_per_portion_share|floatformat:2 }}</span> per {% if item.quantity_denominator > 1 %}part{% else %}item{% endif %}</p>
+        <p class="text-gray-500 text-xs">+ Tax: ${{ item.prorated_tax|floatformat:2 }} + Tip: ${{ item.prorated_tip|floatformat:2 }} = <span class="font-semibold item-share-amount" data-amount="{{ item.get_per_portion_share|floatformat:6 }}">${{ item.get_per_portion_share|floatformat:2 }}</span> per {% if item.quantity_denominator > 1 %}part{% else %}item{% endif %}</p>
     </div>
     {% endif %}
 

--- a/templates/receipts/view.html
+++ b/templates/receipts/view.html
@@ -43,8 +43,8 @@
     
     {% else %}
     
-    <!-- Success Image if all items are claimed -->
-    {% if total_unclaimed == 0 and participant_totals %}
+    <!-- Success Image if all items are claimed (quantity-based, immune to rounding) -->
+    {% if is_fully_claimed and participant_totals %}
     <div class="mb-4 text-center">
         <img src="{% static 'images/success_split.png' %}"
              alt="Successfully split the bill" 

--- a/test/js/regression.spec.js
+++ b/test/js/regression.spec.js
@@ -547,4 +547,53 @@ describe('REGRESSION TESTS - Critical Bug Prevention', () => {
       expect(participantsDiv.textContent).toContain('$25.00');
     });
   });
+
+  describe('Bug: Sub-cent Rounding Drift ($290.75 vs $290.73)', () => {
+    it('should accumulate full-precision shares and round only the final total', () => {
+      // Per-portion share of 11.076666/3 = 3.692222 (non-terminating).
+      // Old behavior multiplied the rounded $3.69 by 3 = $11.07, drifting
+      // from the server's single-rounded $11.08.
+      setBodyHTML(`
+        <div class="item-container" data-item-id="200">
+          <h3>Shared Platter</h3>
+          <div class="item-share-amount" data-amount="3.692222"></div>
+          <input type="number" class="claim-quantity" value="3" min="0" max="3" data-item-id="200">
+        </div>
+        <p id="my-total">$0.00</p>
+      `);
+
+      updateTotal();
+
+      // 3 x 3.692222 = 11.076666 -> rounds once to $11.08
+      expect(document.getElementById('my-total').textContent).toBe('$11.08');
+    });
+
+    it('should keep full precision in data-amount after polling updates', () => {
+      setBodyHTML(`
+        <div class="item-container" data-item-id="201">
+          <h3>Shared Platter</h3>
+          <p class="text-gray-500 text-xs">+ Tax: $0.41 + Tip: $0.67 = <span class="font-semibold item-share-amount" data-amount="3.69">$3.69</span> per item</p>
+        </div>
+      `);
+
+      const pollData = [{
+        item_id: '201',
+        available_quantity: 3,
+        quantity_numerator: 3,
+        quantity_denominator: 3,
+        unit_price: 10.00,
+        total_price: 10.00,
+        per_portion_share: 3.692222,
+        claims: []
+      }];
+
+      updateItemClaims(pollData, 'kuizy', false);
+
+      const shareEl = document.querySelector('.item-share-amount');
+      // data-amount keeps full precision for calculations...
+      expect(shareEl.dataset.amount).toBe('3.692222');
+      // ...while the visible text is rounded to cents
+      expect(shareEl.textContent).toBe('$3.69');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Two follow-ups from PR #20's verification, both verified locally with Playwright plus full suites (188 backend / 206 JS).

### 1. Sub-cent rounding residue broke the fully-claimed state
**Root cause**: participant totals were computed in float SQL over per-item tax/tip prorations quantized to 6dp, so `total_unclaimed = total - sum(shares)` carried sub-cent residues (observed 1e-14…1e-6). The template required `total_unclaimed == 0` for the success state, so fully-claimed receipts showed "Not Claimed $0.00" forever. Separately, the JS summed per-portion values pre-rounded to 2dp, drifting whole cents from the server ($290.75 vs $290.73 in prod).

**Fix**: new `receipts/services/money.py` computes every claim share exactly with `Fraction` and rounds once at the receipt level using largest-remainder cent allocation, with the unclaimed remainder competing for cents like a participant — so `sum(participant totals) + unclaimed == receipt.total` **exactly**, and no participant drifts more than a cent from their exact share. The success illustration now keys off quantity-based `is_fully_claimed` (sum of claim numerators == item numerators). Page total, participant rows, polling JSON, and Venmo pay/charge amounts all read the same allocated values; `data-amount` carries full precision so the client rounds once.

**Verification**: 6 new backend tests reproduce the exact pre-fix residues; independent adversarial pass added penny-split (0.01 three ways → 0.00/0.00/0.01), 7-way and LCM-subdivision splits, and a 15-trial randomized fuzz — money conservation held exactly in every state. E2E: fully-claimed receipt renders the success illustration with rows summing exactly to the total; partial claims show exact unclaimed amounts.

Known benign edge: the pre-finalize JS *estimate* can differ from the final allocated amount by 1 cent on remainder ties (client can't know other participants' remainders); everything displayed after finalization comes from the server allocation.

### 2. Review-app workflow called `fly`, which is never installed
`setup-flyctl` provides only `flyctl`, so the IPv4-allocate and close-time postgres cleanup steps in `fly-review.yml` have been failing with `command not found`, silently masked by `|| echo` guards — leaking per-PR `-db` postgres apps on Fly. Switched to `flyctl`, and added `fly-cleanup.yml` (manual dispatch, dry-run by default) that destroys `pr-N-*` review apps whose PR is closed, to reclaim the existing orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2p3Wece4UCgTHHogmUd5V